### PR TITLE
Fix infinite loop on connection loss

### DIFF
--- a/mtbyteproto.go
+++ b/mtbyteproto.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 )
 
+type mtbyteprotoError error
+
 // Get just one byte because MT's size prefix is overoptimized
 func (c *Client) getone() int {
 	charlet := make([]byte, 1)
-	c.conn.Read(charlet)
+	_, err := c.conn.Read(charlet)
+	if err != nil {
+		panic(mtbyteprotoError(err))
+	}
 	numlet := int(charlet[0])
 	return numlet
 }

--- a/protocol.go
+++ b/protocol.go
@@ -26,8 +26,19 @@ func (c *Client) send(word string) error {
 }
 
 // Get reply
-func (c *Client) receive() (Reply, error) {
-	var reply Reply
+func (c *Client) receive() (reply Reply, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		e, ok := r.(mtbyteprotoError)
+		if ok {
+			err = e
+			return
+		}
+		panic(r)
+	}()
 
 	re := false
 	done := false


### PR DESCRIPTION
getone() and getlen() were returning 0,
io.ReadAtLeast() was then being asked to read 0 bytes,
neither reading anything nor returning any error.
