### PR TITLE
Add function with connection timeout

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 	"strings"
 )
 
@@ -103,12 +104,15 @@ func (c *Client) Close() {
 }
 
 func (c *Client) Connect(user string, password string) error {
+    return c.ConnectTimeout(user, password, time.Second * 15)
+}
 
+func (c *Client) ConnectTimeout(user string, password string, timeout time.Duration) error {
 	var err error
 	if c.TLSConfig != nil {
 		c.conn, err = tls.Dial("tcp", c.address, c.TLSConfig)
 	} else {
-		c.conn, err = net.Dial("tcp", c.address)
+		c.conn, err = net.DialTimeout("tcp", c.address, timeout)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
It will keep also old API, but add reasonable timeout to old function.
Otherwise, if host is dead, it will keep hang until TCP SYN timeout expired, which is quite long by default
Unfortunately, seems there is no option for timeout on TLS mode
